### PR TITLE
When timestamp is not defined

### DIFF
--- a/src/Collector/Neo4jDataCollector.php
+++ b/src/Collector/Neo4jDataCollector.php
@@ -70,7 +70,7 @@ final class Neo4jDataCollector extends AbstractDataCollector
         $mergedArray = array_merge($successfulStatements, $failedStatements);
         uasort(
             $mergedArray,
-            static fn (array $a, array $b) => $a['start_time'] <=> $b['timestamp']
+            static fn (array $a, array $b) => $a['start_time'] <=> ($b['timestamp'] ?? $b['start_time'])
         );
         $this->data['statements'] = $mergedArray;
     }


### PR DESCRIPTION
When the key is not define, use start_time. To fix #84 