### PR TITLE
Rename connections to drivers at config example at README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ This example configures the client to contain two instances.
 neo4j:
   profiling: true
   default_driver: high-availability
-  connections:
+  drivers:
     - alias: high-availability
       dsn: 'neo4j://core1.mydomain.com:7687'
       authentication:


### PR DESCRIPTION
Since bundle no longer defines `connections` configuration and it's now called `drivers`, configuration example at README needs to be updated.